### PR TITLE
Use Project Board as source of truth

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -177,3 +177,65 @@ set_project_status() {
 
   echo "[lib] Issue #$issue_number → $status_name"
 }
+
+# Get issues from the Project Board by status name
+# Usage: get_issues_by_board_status "Refining"
+# Returns JSON array: [{"number": 1, "title": "...", "item_id": "..."}]
+get_issues_by_board_status() {
+  local target_status="$1"
+  local owner="${REPO%%/*}"
+  local project_number="${PROJECT_NUMBER:-1}"
+
+  if [[ -z "$PROJECT_ID" ]]; then
+    echo "[]"
+    return
+  fi
+
+  gh api graphql -f query="
+  {
+    user(login: \"$owner\") {
+      projectV2(number: $project_number) {
+        items(first: 100) {
+          nodes {
+            id
+            fieldValueByName(name: \"Status\") {
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+              }
+            }
+            content {
+              ... on Issue {
+                number
+                title
+                state
+              }
+            }
+          }
+        }
+      }
+    }
+  }" 2>/dev/null | jq --arg status "$target_status" '
+    [.data.user.projectV2.items.nodes[]
+     | select(.fieldValueByName.name == $status)
+     | select(.content.state == "OPEN")
+     | {number: .content.number, title: .content.title, item_id: .id}]'
+}
+
+# Set both board status AND label in one call
+# Usage: set_issue_status <issue_number> <status_name> <label_name>
+set_issue_status() {
+  local issue_number="$1"
+  local board_status="$2"
+  local label="$3"
+  local old_label="${4:-}"
+
+  # Update board
+  set_project_status "$issue_number" "$board_status"
+
+  # Update labels
+  if [[ -n "$old_label" ]]; then
+    gh issue edit "$issue_number" --repo "$REPO" --remove-label "$old_label" --add-label "$label" 2>/dev/null || true
+  else
+    gh issue edit "$issue_number" --repo "$REPO" --add-label "$label" 2>/dev/null || true
+  fi
+}

--- a/refiner.sh
+++ b/refiner.sh
@@ -82,17 +82,20 @@ ensure_labels() {
   echo "[refiner] All required labels verified"
 }
 
-# Return open issues with NO labels (new, unprocessed issues)
+# Get new issues: no board status and no workflow labels
 get_new_issues() {
-  local repo="$1"
-  gh issue list --repo "$repo" --state open --json number,title,labels \
-    | jq '[.[] | select(.labels | length == 0)]'
+  local skip_labels="refining ready approved in-progress done failed system"
+  gh issue list --repo "$REPO" --state open --json number,title,labels --limit 100 \
+    | jq --arg skip "$skip_labels" '
+      ($skip | split(" ")) as $skip_list |
+      [.[] | select(
+        (.labels | map(.name) | map(select(. as $l | $skip_list | index($l))) | length) == 0
+      ) | {number, title}]'
 }
 
-# Return open issues with label "refining"
+# Get issues being refined: board status = "Refining"
 get_refining_issues() {
-  local repo="$1"
-  gh issue list --repo "$repo" --state open --label "refining" --json number,title
+  get_issues_by_board_status "Refining"
 }
 
 # Perform initial refinement of a new issue using claude
@@ -138,8 +141,7 @@ PROMPT
 
   if [[ -n "$response" ]]; then
     echo "[refiner] Got response from claude, posting comment on #$number"
-    gh issue edit "$number" --repo "$REPO" --add-label "refining"
-    set_project_status "$number" "Refining"
+    set_issue_status "$number" "Refining" "refining"
     gh issue comment "$number" --repo "$REPO" --body "${REFINER_MARKER}
 ${response}"
     echo "[refiner] Issue #$number labeled 'refining' and comment posted"
@@ -254,8 +256,7 @@ PROMPT
 ${checklist}"
 
     gh issue edit "$number" --repo "$REPO" --body "$new_body"
-    gh issue edit "$number" --repo "$REPO" --remove-label "refining" --add-label "ready"
-    set_project_status "$number" "Ready"
+    set_issue_status "$number" "Ready" "ready" "refining"
     gh issue comment "$number" --repo "$REPO" --body "${REFINER_MARKER}
 Refinement complete. All checklist items have been filled. This issue is now **ready** for development."
     echo "[refiner] Issue #$number is now ready"
@@ -282,7 +283,7 @@ while true; do
   echo "[refiner] Polling at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 
   # --- New issues (no labels) ---
-  new_issues=$(get_new_issues "$REPO")
+  new_issues=$(get_new_issues)
   new_count=$(echo "$new_issues" | jq 'length')
   echo "[refiner] Found $new_count new issue(s)"
 
@@ -293,7 +294,7 @@ while true; do
   done
 
   # --- Refining issues ---
-  refining_issues=$(get_refining_issues "$REPO")
+  refining_issues=$(get_refining_issues)
   refining_count=$(echo "$refining_issues" | jq 'length')
   echo "[refiner] Found $refining_count refining issue(s)"
 

--- a/solver.sh
+++ b/solver.sh
@@ -92,11 +92,11 @@ fi
 # ---------------------------------------------------------------------------
 
 get_approved_issues() {
-  gh issue list --repo "$REPO" --state open --label approved --json number,title
+  get_issues_by_board_status "Approved"
 }
 
 get_in_progress_issues() {
-  gh issue list --repo "$REPO" --state open --label in-progress --json number,title
+  get_issues_by_board_status "In Progress"
 }
 
 check_stale() {
@@ -110,8 +110,7 @@ check_stale() {
 
   if [[ -z "$comments" || "$comments" == "null" ]]; then
     echo "[solver] No '[solver] Started at' comment found for #$number — marking as failed"
-    gh issue edit "$number" --repo "$REPO" --remove-label in-progress --add-label failed
-    set_project_status "$number" "Failed"
+    set_issue_status "$number" "Failed" "failed" "in-progress"
     gh issue comment "$number" --repo "$REPO" --body "[solver] Marked as failed: no start timestamp found."
     return
   fi
@@ -140,8 +139,7 @@ check_stale() {
       git -C "$REPO_DIR" worktree remove "$WORKTREE_DIR/issue-$number" --force || true
     fi
 
-    gh issue edit "$number" --repo "$REPO" --remove-label in-progress --add-label failed
-    set_project_status "$number" "Failed"
+    set_issue_status "$number" "Failed" "failed" "in-progress"
     gh issue comment "$number" --repo "$REPO" --body "[solver] Marked as failed: timed out after ${elapsed}s (limit: ${SOLVER_TIMEOUT}s)."
   else
     echo "[solver] Issue #$number still within timeout (${elapsed}s / ${SOLVER_TIMEOUT}s)"
@@ -154,9 +152,8 @@ solve_issue() {
 
   echo "[solver] Solving issue #$number — $title"
 
-  # Swap labels: approved -> in-progress
-  gh issue edit "$number" --repo "$REPO" --remove-label approved --add-label in-progress
-  set_project_status "$number" "In Progress"
+  # Swap status: approved -> in-progress
+  set_issue_status "$number" "In Progress" "in-progress" "approved"
 
   # Comment with start timestamp
   local start_ts
@@ -229,8 +226,7 @@ PROMPT_EOF
 
   if [[ "$claude_exit" -ne 0 ]]; then
     echo "[solver] Claude failed with exit code $claude_exit for #$number"
-    gh issue edit "$number" --repo "$REPO" --remove-label in-progress --add-label failed
-    set_project_status "$number" "Failed"
+    set_issue_status "$number" "Failed" "failed" "in-progress"
     gh issue comment "$number" --repo "$REPO" --body "[solver] Failed: claude exited with code $claude_exit."
     git -C "$REPO_DIR" worktree remove "$wt_dir" --force || true
     return
@@ -242,8 +238,7 @@ PROMPT_EOF
 
   if [[ "$commit_count" -eq 0 ]]; then
     echo "[solver] No commits made for #$number — marking as failed"
-    gh issue edit "$number" --repo "$REPO" --remove-label in-progress --add-label failed
-    set_project_status "$number" "Failed"
+    set_issue_status "$number" "Failed" "failed" "in-progress"
     gh issue comment "$number" --repo "$REPO" --body "[solver] Failed: claude produced no commits."
     git -C "$REPO_DIR" worktree remove "$wt_dir" --force || true
     return
@@ -264,9 +259,8 @@ PR_EOF
 
   echo "[solver] PR created: $pr_url"
 
-  # Swap labels: in-progress -> done
-  gh issue edit "$number" --repo "$REPO" --remove-label in-progress --add-label done
-  set_project_status "$number" "Done"
+  # Swap status: in-progress -> done
+  set_issue_status "$number" "Done" "done" "in-progress"
 
   # Comment with PR URL
   gh issue comment "$number" --repo "$REPO" --body "[solver] PR created: $pr_url"


### PR DESCRIPTION
## Summary
- Board status is now the source of truth for both refiner and solver
- Human moves issue in board → scripts detect automatically
- Labels kept in sync for backwards compat
- New shared functions: get_issues_by_board_status, set_issue_status

Closes #12